### PR TITLE
python-snappy 0.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.6.0" %}
-{% set sha256 = "168a98d3f597b633cfeeae7fe1c78a8dfd81f018b866cf7ce9e4c56086af891a" %}
+{% set version = "0.6.1" %}
+{% set sha256 = "b6a107ab06206acc5359d4c5632bd9b22d448702a79b3169b0c62e0fb808bb2a" %}
 
 package:
   name: python-snappy


### PR DESCRIPTION
Update python-snappy to 0.6.1