### PR TITLE
0.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,14 +21,20 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
     - snappy
-    - msinttypes  # [win and py27]
   run:
     - python
 
 test:
+  requires:
+    - python
+    - pip
   imports:
     - snappy
+  commands:
+    - pip check
 
 about:
   home: https://github.com/andrix/python-snappy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.6.0" %}
-{% set sha256 = "168a98d3f597b633cfeeae7fe1c78a8dfd81f018b866cf7ce9e4c56086af891a" %}
+{% set version = "0.6.1" %}
+{% set sha256 = "b6a107ab06206acc5359d4c5632bd9b22d448702a79b3169b0c62e0fb808bb2a" %}
 
 package:
   name: python-snappy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,11 +41,17 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: 'Python library for the snappy compression library from Google'
+  summary: Python library for the snappy compression library from Google
+  description: |
+    Python library for the snappy compression library from Google
   dev_url: https://github.com/andrix/python-snappy
+  doc_url: https://github.com/andrix/python-snappy
 
 extra:
   recipe-maintainers:
     - mariusvniekerk
     - martindurant
     - djsutherland
+  skip-lints:
+    - missing_doc_source_url
+    - missing_license_url


### PR DESCRIPTION
# Python Snappy 0.6.1
upstream: https://github.com/andrix/python-snappy/tree/0.6.1
`setup.py`: https://github.com/andrix/python-snappy/blob/0.6.1/setup.py
license: https://github.com/andrix/python-snappy/blob/0.6.1/LICENSE
changelog: https://github.com/andrix/python-snappy/compare/0.6.0...0.6.1

## Changes
- Bump version and SHA
- Add `pip check` as test
- Update about section

## Notes
- [This adds Python 3.11 support](https://github.com/andrix/python-snappy/commit/5575c80fbbbf3c8b257dfe1c9b9bb3e69ac909a8)